### PR TITLE
adding exception handling;  The delegate processor needs to throw an …

### DIFF
--- a/src/main/java/com/carfax/kinesis/ShutdownNotificationAwareRecordProcessor.java
+++ b/src/main/java/com/carfax/kinesis/ShutdownNotificationAwareRecordProcessor.java
@@ -4,5 +4,5 @@ import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IRecordProcess
 import com.amazonaws.services.kinesis.clientlibrary.interfaces.v2.IShutdownNotificationAware;
 
 public interface ShutdownNotificationAwareRecordProcessor extends IRecordProcessor, IShutdownNotificationAware {
-
+    void handleException(Exception e);
 }

--- a/src/test/groovy/com/carfax/kinesis/TimeIntervalBasedKinesisRecordProcessorSpec.groovy
+++ b/src/test/groovy/com/carfax/kinesis/TimeIntervalBasedKinesisRecordProcessorSpec.groovy
@@ -58,6 +58,21 @@ class TimeIntervalBasedKinesisRecordProcessorSpec extends Specification {
         0 * timeIntervalBasedKinesisRecordProcessor.checkpoint(*_) >> null
     }
 
+    void 'processRecords - Exception'() {
+        given:
+        ProcessRecordsInput processRecordsInput = new ProcessRecordsInput()
+        Exception recordProcessingException = new Exception()
+        1 * timeIntervalBasedKinesisRecordProcessor.delegateProcessor.processRecords(processRecordsInput) >> { throw recordProcessingException }
+
+        when:
+        timeIntervalBasedKinesisRecordProcessor.processRecords(processRecordsInput)
+
+        then:
+        1 * timeIntervalBasedKinesisRecordProcessor.delegateProcessor.handleException(
+                { Exception e -> e.cause.is(recordProcessingException) }
+        )
+    }
+
     void 'shutdown - ZOMBIE'() {
         given:
         ShutdownInput shutdownInput = new ShutdownInput().withShutdownReason(ShutdownReason.ZOMBIE)


### PR DESCRIPTION
…Exception to keep the TimeIntervalBasedKinesisRecordProcessor from checkpointing.